### PR TITLE
Potential fix for code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/app/api/ai-team/coordinate/route.ts
+++ b/app/api/ai-team/coordinate/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'User request is required' }, { status: 400 })
     }
 
-    console.log(`AI Team: Processing ${step} step for request:`, userRequest.substring(0, 100));
+    console.log('AI Team: Processing %s step for request:', step, userRequest.substring(0, 100));
 
     switch (step) {
       case 'analyze':


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/1](https://github.com/otdoges/zapdev/security/code-scanning/1)

To fix the issue, sanitize the `step` variable before using it in the format string. This can be achieved by ensuring that `step` is a string and escaping any special characters that could be interpreted as format specifiers. Alternatively, use a `%s` specifier in the format string and pass `step` as an argument to `console.log`. This approach is safer and aligns with the recommendation provided in the background section.

Changes to make:
1. Modify the `console.log` statement on line 28 to use a `%s` specifier for `step`.
2. Pass `step` as an additional argument to `console.log`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
