### PR TITLE
Potential fix for code scanning alert no. 33: Disallow invocation of `require()`

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -107,5 +108,5 @@ export default {
   		}
   	}
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/33](https://github.com/otdoges/zapdev/security/code-scanning/33)

To fix this issue, replace the invocation of `require("tailwindcss-animate")` with an ES module import. Since the `plugins` array expects plugin modules, import `tailwindcss-animate` at the top of the file and reference the imported plugin in the array. Specifically, add an import statement for `tailwindcss-animate` at the top of `tailwind.config.ts` (after other imports), and change the `plugins` array to use the imported identifier. No additional methods, variable definitions, or custom logic are needed. This change will eliminate the ESLint error while preserving the original functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
