### PR TITLE
Potential fix for code scanning alert no. 31: Disallow the `any` type

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, Session } from '@supabase/supabase-js'
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
@@ -61,6 +61,6 @@ export const getCurrentUser = async () => {
   return user
 }
 
-export const onAuthStateChange = (callback: (event: string, session: any) => void) => {
+export const onAuthStateChange = (callback: (event: string, session: Session | null) => void) => {
   return supabase.auth.onAuthStateChange(callback)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/31](https://github.com/otdoges/zapdev/security/code-scanning/31)

To fix the problem, we should replace the `any` type in the callback argument with Supabase’s official session type. Supabase’s JS client exports a `Session` type that describes the shape of the session object. We need to import `Session` from `@supabase/supabase-js` and update the callback signature to use `(event: string, session: Session | null) => void`, since the session can be `null` when the user is not signed in. The edit is required in `src/lib/supabase.ts` at line 64. We will need to add the import for `Session` at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
