### PR TITLE
Potential fix for code scanning alert no. 30: Disallow the `any` type

### DIFF
--- a/src/lib/multiModelAI.ts
+++ b/src/lib/multiModelAI.ts
@@ -5,6 +5,11 @@ import systemPrompt from './systemPrompt';
 import { geminiManager, type TaskAssignment } from './geminiManager';
 import { kimiK2, type KimiK2Response } from './kimiK2';
 
+interface GenerationOptions {
+  temperature?: number;
+  maxTokens?: number;
+  includeReasoning?: boolean;
+}
 export interface MultiModelResponse {
   content: string;
   model: string;
@@ -338,8 +343,8 @@ class MultiModelAI {
   }
 
   private async generateLegacyMultiModelResponse(
-    messages: any[],
-    options: any
+    messages: { role: string; content: string }[],
+    options: GenerationOptions
   ): Promise<AggregatedResponse> {
     // Legacy implementation for fallback
     const { temperature = 0.7, maxTokens = 4000, includeReasoning = true } = options;
@@ -390,8 +395,8 @@ class MultiModelAI {
   }
 
   private async streamLegacyResponse(
-    messages: any[],
-    options: any
+    messages: { role: string; content: string }[],
+    options: GenerationOptions
   ): Promise<AsyncIterable<string>> {
     const { temperature = 0.7, maxTokens = 4000 } = options;
     const model = groq(MULTI_MODEL_CONFIG.primary); // Use best preview model for streaming


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/30](https://github.com/otdoges/zapdev/security/code-scanning/30)

To resolve this issue, we need to replace the `any` type with a more specific type for `options`. Since `options` is expected to have properties like `temperature`, `maxTokens`, and possibly others, we can define an interface named `GenerationOptions` that outlines its structure. This ensures type safety and makes the code easier to understand and maintain.

Steps to fix:
1. Define a new interface `GenerationOptions` that includes `temperature`, `maxTokens`, and `includeReasoning`.
2. Replace `options: any` with `options: GenerationOptions` in the method signatures for `generateLegacyMultiModelResponse` and `streamLegacyResponse`.
3. Ensure all usage of `options` matches the new type.
4. Add the interface definition within the same file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
