### PR TITLE
Potential fix for code scanning alert no. 38: Incomplete string escaping or encoding

### DIFF
--- a/src/utils/nextjs-project-generator.ts
+++ b/src/utils/nextjs-project-generator.ts
@@ -57,7 +57,7 @@ export default function HomePage() {
         </div>
         <div className="bg-white rounded-lg shadow-lg p-8">
           <pre className="whitespace-pre-wrap text-sm text-gray-800">
-            ${code.replace(/`/g, '\\`')}
+            ${code.replace(/\\/g, '\\\\').replace(/`/g, '\\`')}
           </pre>
         </div>
       </div>


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/38](https://github.com/otdoges/zapdev/security/code-scanning/38)

To fix this problem, we should escape both backslashes (`\`) and backticks (`` ` ``) in the `code` string before interpolating it into the template literal. The best way is to use a `.replace()` chain or a single `.replace()` with a regular expression that matches both characters globally, replacing backslashes with double backslashes (`\\`) and backticks with escaped backticks (`\``). This change should be made on line 60 of `src/utils/nextjs-project-generator.ts`. No new methods or imports are required; only the replacement logic needs to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
