### PR TITLE
Potential fix for code scanning alert no. 77: Disallow the `any` type

### DIFF
--- a/src/lib/e2b-service.ts
+++ b/src/lib/e2b-service.ts
@@ -83,7 +83,7 @@ class E2BService {
    * Get E2B API key from environment
    */
   private getApiKey(): string | null {
-    return process.env.E2B_API_KEY || (import.meta as any).env?.VITE_E2B_API_KEY || null;
+    return process.env.E2B_API_KEY || (import.meta as { env?: { VITE_E2B_API_KEY?: string } }).env?.VITE_E2B_API_KEY || null;
   }
 
   /**


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/77](https://github.com/otdoges/zapdev/security/code-scanning/77)

To fix the problem, we should avoid using `any` and instead provide a proper type for `import.meta.env`. In Vite projects, you can extend the `ImportMetaEnv` interface in a `vite-env.d.ts` or similar declaration file, but since we can only edit the shown code, we should use a type assertion that is more specific than `any`. The best way is to define an interface for the expected shape of `import.meta.env` (at least including `VITE_E2B_API_KEY?: string`) and use it for the type assertion. This change should be made on line 86 in the `getApiKey` method.

No new imports are needed, and the change is limited to the type assertion in the `getApiKey` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
