### PR TITLE
Potential fix for code scanning alert no. 76: Disallow the `any` type

### DIFF
--- a/src/lib/e2b-service.ts
+++ b/src/lib/e2b-service.ts
@@ -47,7 +47,7 @@ class E2BService {
   /**
    * Track E2B usage events for analytics
    */
-  private trackEvent(eventName: string, metadata: Record<string, any>): void {
+  private trackEvent(eventName: string, metadata: Record<string, unknown>): void {
     try {
       const MAX_EVENTS = 1000; // Prevent unbounded growth
 


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/76](https://github.com/otdoges/zapdev/security/code-scanning/76)

To fix the problem, we should replace the use of `any` in `Record<string, any>` with a safer alternative. The best general-purpose replacement is `unknown`, which preserves type safety while still allowing for flexibility. This means changing the parameter type to `Record<string, unknown>`. This change will not affect existing functionality, as all usages of `metadata` in the method are simply spread into a new object and stored, not manipulated in a way that requires knowledge of the value types. The only change required is on line 50 of `src/lib/e2b-service.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
