### PR TITLE
Potential fix for code scanning alert no. 124: Clear-text logging of sensitive information

### DIFF
--- a/scripts/setup-env.js
+++ b/scripts/setup-env.js
@@ -289,8 +289,8 @@ async function checkEnvironmentVariables() {
   const e2bKey = process.env.VITE_E2B_API_KEY;
   
   logInfo(`Runtime check:`);
-  logInfo(`VITE_GROQ_API_KEY: ${groqKey ? `Set (${groqKey.substring(0, 8)}...)` : 'Not set'}`);
-  logInfo(`VITE_E2B_API_KEY: ${e2bKey ? `Set (${e2bKey.substring(0, 8)}...)` : 'Not set'}`);
+  logInfo(`VITE_GROQ_API_KEY: ${groqKey ? 'Set' : 'Not set'}`);
+  logInfo(`VITE_E2B_API_KEY: ${e2bKey ? 'Set' : 'Not set'}`);
   
   // Check all existing env files
   const envFiles = ['.env.local', '.env'];
@@ -303,8 +303,8 @@ async function checkEnvironmentVariables() {
       const fileGroqKey = env.VITE_GROQ_API_KEY;
       const fileE2bKey = env.VITE_E2B_API_KEY;
       
-      logInfo(`  VITE_GROQ_API_KEY: ${fileGroqKey ? `Set (${fileGroqKey.substring(0, 8)}...)` : 'Not set'}`);
-      logInfo(`  VITE_E2B_API_KEY: ${fileE2bKey ? `Set (${fileE2bKey.substring(0, 8)}...)` : 'Not set'}`);
+      logInfo(`  VITE_GROQ_API_KEY: ${fileGroqKey ? 'Set' : 'Not set'}`);
+      logInfo(`  VITE_E2B_API_KEY: ${fileE2bKey ? 'Set' : 'Not set'}`);
     }
   }
   


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/124](https://github.com/otdoges/zapdev/security/code-scanning/124)

To fix the problem, we should avoid logging any part of the sensitive API keys. Instead, we can log whether the key is set or not, without revealing any portion of its value. This means updating the log statements in `checkEnvironmentVariables` so that they only indicate presence/absence of the keys, not their values or substrings. The changes are limited to the log statements on lines 292, 293, 306, and 307 in `scripts/setup-env.js`. No new imports or methods are required; only the log message format needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated environment setup logging to fully redact secret values, showing only whether each key is set or not.
  - Standardized runtime and per-file checks to avoid displaying any key fragments in console output.
  - No behavior changes to detection logic; only messaging adjusted for safer, cleaner logs.
  - Improves security and reduces noise for developers running setup locally and in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->