### PR TITLE
Potential fix for code scanning alert no. 122: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
     "undici": "^5.28.5",
     "vaul": "^1.1.2",
     "vercel": "^44.7.3",
-    "zod": "^4.0.17"
+    "zod": "^4.0.17",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/lib/search-service.ts
+++ b/src/lib/search-service.ts
@@ -316,9 +316,16 @@ export class BraveSearchService {
   }
 
   private extractTextContent(html: string): string {
-    return html
-      .replace(/<script[^>]*>.*?<\/script>/gi, '')
-      .replace(/<style[^>]*>.*?<\/style>/gi, '')
+    // Repeatedly remove <script> and <style> tags and their content
+    let sanitized = html;
+    let previous;
+    do {
+      previous = sanitized;
+      sanitized = sanitized
+        .replace(/<script[^>]*>.*?<\/script>/gis, '')
+        .replace(/<style[^>]*>.*?<\/style>/gis, '');
+    } while (sanitized !== previous);
+    return sanitized
       .replace(/<[^>]*>/g, ' ')
       .replace(/\s+/g, ' ')
       .trim();


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/122](https://github.com/otdoges/zapdev/security/code-scanning/122)

The best way to fix this problem is to use a well-tested HTML sanitization library, such as `sanitize-html`, to reliably remove all `<script>` and `<style>` tags and their content, as well as any other potentially dangerous HTML. However, if adding a dependency is not an option, a safer alternative is to repeatedly apply the regular expression replacements for `<script>` and `<style>` tags until no more matches are found. This ensures that all instances, including those that may appear after previous replacements, are removed.

To implement this fix in `src/lib/search-service.ts`, update the `extractTextContent` method (lines 318-325) to repeatedly remove `<script>` and `<style>` tags and their content until none remain, before proceeding to strip all other tags and whitespace. No new imports are needed for the repeated replacement approach.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
