### PR TITLE
Potential fix for code scanning alert no. 121: Incomplete multi-character sanitization

### DIFF
--- a/src/lib/search-service.ts
+++ b/src/lib/search-service.ts
@@ -316,12 +316,22 @@ export class BraveSearchService {
   }
 
   private extractTextContent(html: string): string {
-    return html
-      .replace(/<script[^>]*>.*?<\/script>/gi, '')
-      .replace(/<style[^>]*>.*?<\/style>/gi, '')
-      .replace(/<[^>]*>/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim();
+    let sanitized = html;
+    let previous;
+    // Remove all <script> tags (including content) repeatedly
+    do {
+      previous = sanitized;
+      sanitized = sanitized.replace(/<script[^>]*>.*?<\/script>/gis, '');
+    } while (sanitized !== previous);
+    // Remove all <style> tags (including content) repeatedly
+    do {
+      previous = sanitized;
+      sanitized = sanitized.replace(/<style[^>]*>.*?<\/style>/gis, '');
+    } while (sanitized !== previous);
+    // Remove all other HTML tags
+    sanitized = sanitized.replace(/<[^>]*>/g, ' ');
+    // Collapse whitespace and trim
+    return sanitized.replace(/\s+/g, ' ').trim();
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/121](https://github.com/otdoges/zapdev/security/code-scanning/121)

The best way to fix this problem is to ensure that all instances of `<script>` and `<style>` tags are completely removed from the input, even if they appear consecutively or are nested. This can be achieved by repeatedly applying the regular expression replacement until no more matches are found, as described in the background. Alternatively, using a well-tested library such as `sanitize-html` would be preferable, but if that is not an option, the repeated replacement approach is effective.

Specifically, in `src/lib/search-service.ts`, within the `extractTextContent` method (lines 318-325), replace the single-pass `.replace()` calls for `<script>` and `<style>` tags with a loop that repeatedly applies the replacements until the input no longer changes. This ensures that all such tags are removed, regardless of their arrangement in the input.

No new methods or imports are needed unless you choose to use a library. For the repeated replacement approach, simply refactor the code within the method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
