### PR TITLE
Potential fix for code scanning alert no. 155: Information exposure through a stack trace

### DIFF
--- a/api-dev-server.ts
+++ b/api-dev-server.ts
@@ -156,9 +156,7 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
       console.error(`Error handling ${endpoint}:`, error);
       res.writeHead(500);
       res.end(JSON.stringify({ 
-        error: 'Internal Server Error',
-        message: error.message,
-        stack: error.stack
+        error: 'Internal Server Error'
       }));
     }
   });


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/155](https://github.com/otdoges/zapdev/security/code-scanning/155)

To fix the problem, the code should avoid sending the error's stack trace and message to the client in the HTTP response. Instead, it should log the full error (including stack trace) on the server side for debugging purposes, and return a generic error message to the client. This change should be made in the catch block inside the `req.on('end', async () => { ... })` handler, specifically replacing the response at lines 158–162. No new dependencies are required; use `console.error` for server-side logging. Only the response body sent to the client should be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
