### PR TITLE
Potential fix for code scanning alert no. 186: Incomplete multi-character sanitization

### DIFF
--- a/src/lib/search-service.ts
+++ b/src/lib/search-service.ts
@@ -316,19 +316,10 @@ export class BraveSearchService {
   }
 
   private extractTextContent(html: string): string {
-    // Repeatedly remove <script> and <style> tags and their content
-    let sanitized = html;
-    let previous;
-    do {
-      previous = sanitized;
-      sanitized = sanitized
-        .replace(/<script[^>]*>.*?<\/script>/gis, '')
-        .replace(/<style[^>]*>.*?<\/style>/gis, '');
-    } while (sanitized !== previous);
-    return sanitized
-      .replace(/<[^>]*>/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim();
+    // Use cheerio to robustly remove <script> and <style> tags and extract text
+    const $ = cheerio.load(html);
+    $('script, style').remove();
+    return $.root().text().replace(/\s+/g, ' ').trim();
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/186](https://github.com/otdoges/zapdev/security/code-scanning/186)

The best way to fix this problem is to use a proper HTML parser to remove `<script>` and `<style>` elements and their content, rather than relying on regular expressions. Since `cheerio` is already imported in the file, we can use it to parse the HTML, remove all `<script>` and `<style>` elements, and then extract the text content. This approach is robust against malformed or obfuscated tags and does not rely on repeated regex replacements. The change should be made in the `extractTextContent` method (lines 318–332), replacing the current implementation with one that uses `cheerio` to remove the unwanted elements and extract the text.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Cleaner text displayed from HTML sources by excluding script/style content and normalizing whitespace.
- Refactor
  - Reworked HTML text extraction to use a DOM-based parsing approach for more consistent results.
  - Simplified internal logic by removing iterative string-based cleanup.
  - No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->