### PR TITLE
Potential fix for code scanning alert no. 640: Bad HTML filtering regexp

### DIFF
--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -92,7 +92,7 @@ export const validateResponse = (content: string): { isValid: boolean; error?: s
   
   // Check for potentially malicious patterns
   const maliciousPatterns = [
-    /<script[^>]*>[\s\S]*?<\/script>/is,
+    /<script[^>]*>[\s\S]*?<\/script[^<]*>/is,
     /\bjavascript:/i,
     // quoted or unquoted inline handlers
     /\bon\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/i,


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/640](https://github.com/otdoges/zapdev/security/code-scanning/640)

The best way to fix this problem is to ensure the regular expression matches malformed or "browser-accepted" script closing tags such as `</script foo="bar">`, as well as extra whitespace and other permitted endings. This can be achieved by modifying the regex so that the closing tag matches `</script` followed by optional whitespace and anything that is not a `<` character (e.g., `</script[^<]*>`) instead of strictly enforcing `</script>`. 

**Edits required:**  
- In file `src/utils/security.ts`, update the regular expression at line 95 in the `maliciousPatterns` array to account for script closing tags that may contain extra attributes or whitespace.  
- No extra imports or function definitions are required; only the regex pattern needs to be fixed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of embedded scripts in responses, reducing the risk of potentially malicious content reaching users.
  * Enhanced validation for edge cases in script tags to provide more robust protection without impacting normal content.
  * No changes required from users; existing workflows continue to function as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->