### PR TITLE
Potential fix for code scanning alert no. 638: CORS misconfiguration for credentials transfer

### DIFF
--- a/api-dev-server.ts
+++ b/api-dev-server.ts
@@ -737,16 +737,14 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
   const isTrustedOrigin = origin && TRUSTED_ORIGINS_FOR_CREDENTIALS.includes(origin) && isValidOrigin(origin);
   const isAllowedOrigin = origin && CONFIG.CORS_ORIGINS.includes(origin) && isValidOrigin(origin);
   
-  if (isAllowedOrigin) {
+  if (isTrustedOrigin) {
+    // Only echo origin and allow credentials for trusted origins
     res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, DELETE');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
-    
-    // Only enable credentials for trusted origins to prevent credential hijacking
-    if (isTrustedOrigin) {
-      res.setHeader('Access-Control-Allow-Credentials', 'true');
-    }
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
   }
+  // Optionally handle non-credentialed CORS here. For maximum safety, do not dynamically echo origins for untrusted sources.
   
   if (req.method === 'OPTIONS') {
     res.writeHead(204);


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/638](https://github.com/otdoges/zapdev/security/code-scanning/638)

**General fix:**  
Only set `Access-Control-Allow-Origin` to the dynamic `origin` value if (a) that origin is in a *trusted whitelist* that is allowed to receive credentials, and (b) credentials will be allowed. For origins permitted for non-credentialed access, either do not send `Access-Control-Allow-Origin` at all, or set it to a safe, static value (preferably none), or handle them separately.

**Detailed fix:**  
- Replace the current block (lines 740–749) that sets CORS headers.
- Only set `Access-Control-Allow-Origin` to the value of `origin` if `isTrustedOrigin` is true.
- If the origin is *not* trusted for credentials, do not set `Access-Control-Allow-Origin` (or, optionally, set to a static safe value, but only if you are sure it doesn't conflict with browser expectations).
- Always be sure to set `Access-Control-Allow-Credentials: true` only when the origin is trusted.
- This change makes the code robust against future additions to `CONFIG.CORS_ORIGINS` that aren't safe for credentials.

**What to change / add:**
- Edit in `api-dev-server.ts`, within the main request handler.
- Ensure you preserve valid existing CORS logic, but the dynamic echoing of `origin` must only occur in the credentialed, trusted path.  
- If you wish to also support non-credentialed CORS for some other list, it MUST be handled in a separate, safe way (e.g., static origins not inferred from client data).
- No new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
