### PR TITLE
Potential fix for code scanning alert no. 695: Uncontrolled command line

### DIFF
--- a/lib/git-workflow-manager.ts
+++ b/lib/git-workflow-manager.ts
@@ -221,10 +221,10 @@ export class GitWorkflowManager {
       const repoPath = repository.localPath;
       
       // Add changes
-      await execAsync(`cd ${repoPath} && git add .`);
+      await execFileAsync('git', ['add', '.'], { cwd: repoPath });
 
       // Check if there are changes to commit
-      const { stdout: statusOutput } = await execAsync(`cd ${repoPath} && git status --porcelain`);
+      const { stdout: statusOutput } = await execFileAsync('git', ['status', '--porcelain'], { cwd: repoPath });
       if (!statusOutput.trim()) {
         return { success: false, message: 'No changes to commit', filesChanged };
       }
@@ -240,8 +240,8 @@ ${filesChanged.map(file => `- ${file}`).join('\n')}
 Co-Authored-By: AI Agent <ai-agent@zapdev.com>`;
 
       // Commit changes
-      const commitCommand = `cd ${repoPath} && git commit -m "${fullCommitMessage}"`;
-      const { stdout: commitOutput } = await execAsync(commitCommand);
+      const { stdout: commitOutput } = await execFileAsync('git', ['commit', '-m', fullCommitMessage], { cwd: repoPath });
+
 
       // Extract commit hash
       const commitHashMatch = commitOutput.match(/\[.*?([a-f0-9]{7,})\]/);


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/695](https://github.com/otdoges/zapdev/security/code-scanning/695)

To fix this issue, switch from using `execAsync` to `execFileAsync` to avoid shell evaluation and properly handle commit message arguments. Instead of building a shell command as a single string, run `git` directly and supply arguments as an array, placing the commit message in the appropriate argument (including line breaks, if necessary). This prevents the user's description from ever being interpreted by a shell. 

Edit the auto-commit functionality in `lib/git-workflow-manager.ts`:
- Replace the `execAsync` call that commits with a call to `execFileAsync`, passing the commit message as an array argument to `-m`.
- Ensure working directory is correctly set via the `cwd` option on `execFileAsync`, rather than using `cd`.
- Ensure imports for `execFile` and `promisify` remain as they are.

No changes elsewhere are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
