### PR TITLE
Potential fix for code scanning alert no. 670: Server-side request forgery

### DIFF
--- a/app/api/apply-ai-code/route.ts
+++ b/app/api/apply-ai-code/route.ts
@@ -575,8 +575,9 @@ if result.stderr:
       try {
         console.log('[apply-ai-code] Auto-generating missing components...');
         
+        const trustedBaseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
         const autoCompleteResponse = await fetch(
-          `${request.nextUrl.origin}/api/auto-complete-components`,
+          `${trustedBaseUrl}/api/auto-complete-components`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Potential fix for [https://github.com/otdoges/zapdev/security/code-scanning/670](https://github.com/otdoges/zapdev/security/code-scanning/670)

To prevent SSRF, the outgoing fetch URL on line 579 should use either a hardcoded trusted origin (the real service host/base URL) or select from a strict allow-list, rather than dynamically referencing `request.nextUrl.origin`. The best fix for Next.js API routes is to use a fixed value such as `process.env.NEXT_PUBLIC_BASE_URL` (set in your environment for the service's public URL), or `'http://localhost:3000'` for local development, falling back as needed. The fix should replace `${request.nextUrl.origin}` with the trusted base URL.  
- Change only the string construction for the fetch URL at line 579, so it does not use user-controlled values.
- If necessary, you may introduce a local variable to select the correct base URL.
- No changes to the actual request payload or logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
